### PR TITLE
Fix handling of -coverprofile

### DIFF
--- a/coverfail.go
+++ b/coverfail.go
@@ -67,7 +67,7 @@ func run(coverprofile string, threshold float64) error {
 func buildOptionalTestArgs(coverprofile string) []string {
 	args := []string{}
 	if coverprofile != "" {
-		args = append(args, "-coverprofile=", coverprofile)
+		args = append(args, "-coverprofile", coverprofile)
 	}
 	return args
 }


### PR DESCRIPTION
The logic in coverfail currently adds two options if -coverprofile is set: "-coverprofile=" and the name of the desired profile.  This effectively disables the output of a coverage profile.  To correct this, the equal sign is omitted, which will cause the following argument to be interpreted as a value for the option.